### PR TITLE
Update to i18nlint-common 2.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,11 @@ limitations under the License.
 
 ## Release Notes
 
+### v1.2.0
+
+- updated dependencies, including updating to i18nlint-common 2.x
+- parser now returns an array of IntermediateRepresentation objects
+
 ### v1.1.0
 
 - updated dependencies

--- a/package.json
+++ b/package.json
@@ -36,9 +36,9 @@
         "npm-run-all": "^4.1.5"
     },
     "dependencies": {
-        "i18nlint-common": "^1.3.0",
+        "i18nlint-common": "^2.1.0",
         "ilib-locale": "^1.2.2",
         "ilib-loctool-po": "^1.6.2",
-        "ilib-tools-common": "^1.4.0"
+        "ilib-tools-common": "^1.7.0"
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-lint-python-gnu",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "main": "./src/index.js",
     "type": "module",
     "exports": {

--- a/src/POParser.js
+++ b/src/POParser.js
@@ -1,7 +1,7 @@
 /*
  * POParser.js - a parser for PO files
  *
- * Copyright © 2022 JEDLSoft
+ * Copyright © 2022-2023 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 
-import { Parser } from 'i18nlint-common';
+import { Parser, IntermediateRepresentation } from 'i18nlint-common';
 import {
     ResourceString,
     ResourceArray,
@@ -142,11 +142,11 @@ class POParser extends Parser {
         const pofile = this.potype.newFile(this.filePath);
         pofile.extract();
         this.ts = pofile.getTranslationSet();
-        return this.ts.getAll();
-    }
-
-    getResources() {
-        return this.ts.getAll();
+        return [new IntermediateRepresentation({
+            type: "resource",
+            ir: this.ts.getAll(),
+            filePath: this.filePath
+        })];
     }
 }
 

--- a/test/testPOParser.js
+++ b/test/testPOParser.js
@@ -1,7 +1,7 @@
 /*
  * testPOParser.js - test the parser factory
  *
- * Copyright © 2022 JEDLSoft
+ * Copyright © 2022-2023 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,15 +43,17 @@ export const testPOParser = {
     },
 
     testPOParserParse: function(test) {
-        test.expect(4);
+        test.expect(6);
 
         const parser = new POParser({
             filePath: "./test/testfiles/test.po"
         });
         test.ok(parser);
-        parser.parse();
+        const irArray = parser.parse();
+        test.ok(Array.isArray(irArray));
+        test.equal(irArray[0].getType(), "resource");
 
-        const resources = parser.getResources();
+        const resources = irArray[0].getRepresentation();
         test.ok(resources);
         test.ok(Array.isArray(resources));
         test.equal(resources.length, 4);
@@ -60,15 +62,16 @@ export const testPOParser = {
     },
 
     testPOParserParseRightContents: function(test) {
-        test.expect(18);
+        test.expect(19);
 
         const parser = new POParser({
             filePath: "./test/testfiles/test.po"
         });
         test.ok(parser);
-        parser.parse();
+        const irArray = parser.parse();
+        test.ok(Array.isArray(irArray));
 
-        const resources = parser.getResources();
+        const resources = irArray[0].getRepresentation();
         test.ok(resources);
 
         test.equal(resources[0].getSource(), "string 1");
@@ -98,15 +101,16 @@ export const testPOParser = {
     },
 
     testPOParserParseTranslatedFile: function(test) {
-        test.expect(26);
+        test.expect(27);
 
         const parser = new POParser({
             filePath: "./test/testfiles/de-DE.po"
         });
         test.ok(parser);
-        parser.parse();
+        const irArray = parser.parse();
+        test.ok(Array.isArray(irArray));
 
-        const resources = parser.getResources();
+        const resources = irArray[0].getRepresentation();
         test.ok(resources);
 
         test.equal(resources[0].getSource(), "string 1");
@@ -147,7 +151,7 @@ export const testPOParser = {
     },
 
     testPOParserParseTranslatedFileWithPathTemplate: function(test) {
-        test.expect(26);
+        test.expect(27);
 
         const parser = new POParser({
             filePath: "./test/testfiles/test_de_DE.po",
@@ -156,9 +160,10 @@ export const testPOParser = {
             }
         });
         test.ok(parser);
-        parser.parse();
+        const irArray = parser.parse();
+        test.ok(Array.isArray(irArray));
 
-        const resources = parser.getResources();
+        const resources = irArray[0].getRepresentation();
         test.ok(resources);
 
         test.equal(resources[0].getSource(), "string 1");
@@ -196,7 +201,6 @@ export const testPOParser = {
         test.equal(resources[3].getTargetLocale(), "de-DE");
 
         test.done();
-    },
-
+    }
 };
 

--- a/test/testPrintfMatchRule.js
+++ b/test/testPrintfMatchRule.js
@@ -1,7 +1,7 @@
 /*
  * testPrintfMatchRule.js - test the substitution parameter rule
  *
- * Copyright © 2022 JEDLSoft
+ * Copyright © 2022-2023 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@ import { ResourceString } from 'ilib-tools-common';
 
 import PrintfMatchRule from '../src/PrintfMatchRule.js';
 
-import { Result } from 'i18nlint-common';
+import { Result, IntermediateRepresentation } from 'i18nlint-common';
 
 export const testPrintfMatchRules = {
     testPrintfMatchRuleStyle: function(test) {
@@ -88,15 +88,18 @@ export const testPrintfMatchRules = {
 
         const actual = rule.match({
             locale: "de-DE",
-            resource: new ResourceString({
-                key: "printf.test",
-                sourceLocale: "en-US",
-                source: 'This string contains a %s string in it.',
-                targetLocale: "de-DE",
-                target: "Diese Zeichenfolge enthält keinen anderen Zeichenfolgen.",
-                pathName: "a/b/c.xliff"
-            }),
-            file: "x"
+            ir: new IntermediateRepresentation({
+                type: "resource",
+                ir: [new ResourceString({
+                    key: "printf.test",
+                    sourceLocale: "en-US",
+                    source: 'This string contains a %s string in it.',
+                    targetLocale: "de-DE",
+                    target: "Diese Zeichenfolge enthält keinen anderen Zeichenfolgen.",
+                    pathName: "a/b/c.xliff"
+                })],
+                filePath: "x"
+            })
         });
         // if the source contains native quotes, the target must too
         const expected = new Result({
@@ -122,15 +125,18 @@ export const testPrintfMatchRules = {
         // no parameters in source or target is okay
         const actual = rule.match({
             locale: "de-DE",
-            resource: new ResourceString({
-                key: "printf.test",
-                sourceLocale: "en-US",
-                source: 'This string contains “quotes” in it.',
-                targetLocale: "de-DE",
-                target: 'Diese Zeichenfolge enthält "Anführungszeichen".',
-                pathName: "a/b/c.xliff"
-            }),
-            file: "x"
+            ir: new IntermediateRepresentation({
+                type: "resource",
+                ir: [new ResourceString({
+                    key: "printf.test",
+                    sourceLocale: "en-US",
+                    source: 'This string contains “quotes” in it.',
+                    targetLocale: "de-DE",
+                    target: 'Diese Zeichenfolge enthält "Anführungszeichen".',
+                    pathName: "a/b/c.xliff"
+                })],
+                filePath: "x"
+            })
         });
         test.ok(!actual);
 
@@ -145,15 +151,18 @@ export const testPrintfMatchRules = {
 
         const actual = rule.match({
             locale: "de-DE",
-            resource: new ResourceString({
-                key: "printf.test",
-                sourceLocale: "en-US",
-                source: 'This string contains a %s string in it.',
-                targetLocale: "de-DE",
-                target: "Diese Zeichenfolge enthält %s anderen Zeichenfolgen %s.",
-                pathName: "a/b/c.xliff"
-            }),
-            file: "x"
+            ir: new IntermediateRepresentation({
+                type: "resource",
+                ir: [new ResourceString({
+                    key: "printf.test",
+                    sourceLocale: "en-US",
+                    source: 'This string contains a %s string in it.',
+                    targetLocale: "de-DE",
+                    target: "Diese Zeichenfolge enthält %s anderen Zeichenfolgen %s.",
+                    pathName: "a/b/c.xliff"
+                })],
+                filePath: "x"
+            })
         });
         // if the source contains native quotes, the target must too
         const expected = new Result({
@@ -179,15 +188,18 @@ export const testPrintfMatchRules = {
         // no parameters in source or target is okay
         const actual = rule.match({
             locale: "de-DE",
-            resource: new ResourceString({
-                key: "printf.test",
-                sourceLocale: "en-US",
-                source: 'This string contains %s in it.',
-                targetLocale: "de-DE",
-                target: 'Diese Zeichenfolge enthält %s.',
-                pathName: "a/b/c.xliff"
-            }),
-            file: "x"
+            ir: new IntermediateRepresentation({
+                type: "resource",
+                ir: [new ResourceString({
+                    key: "printf.test",
+                    sourceLocale: "en-US",
+                    source: 'This string contains %s in it.',
+                    targetLocale: "de-DE",
+                    target: 'Diese Zeichenfolge enthält %s.',
+                    pathName: "a/b/c.xliff"
+                })],
+                filePath: "x"
+            })
         });
         test.ok(!actual);
 
@@ -203,15 +215,18 @@ export const testPrintfMatchRules = {
         // no parameters in source or target is okay
         const actual = rule.match({
             locale: "de-DE",
-            resource: new ResourceString({
-                key: "printf.test",
-                sourceLocale: "en-US",
-                source: 'This string %d contains %s in it.',
-                targetLocale: "de-DE",
-                target: 'Diese Zeichenfolge enthält %s %d.',
-                pathName: "a/b/c.xliff"
-            }),
-            file: "x"
+            ir: new IntermediateRepresentation({
+                type: "resource",
+                ir: [new ResourceString({
+                    key: "printf.test",
+                    sourceLocale: "en-US",
+                    source: 'This string %d contains %s in it.',
+                    targetLocale: "de-DE",
+                    target: 'Diese Zeichenfolge enthält %s %d.',
+                    pathName: "a/b/c.xliff"
+                })],
+                filePath: "x"
+            })
         });
         test.ok(!actual);
 
@@ -227,15 +242,18 @@ export const testPrintfMatchRules = {
         // no parameters in source or target is okay
         const actual = rule.match({
             locale: "de-DE",
-            resource: new ResourceString({
-                key: "printf.test",
-                sourceLocale: "en-US",
-                source: 'This string contains %0$-#05.2zd in it.',
-                targetLocale: "de-DE",
-                target: 'Diese Zeichenfolge enthält %0$-#05.2zd.',
-                pathName: "a/b/c.xliff"
-            }),
-            file: "x"
+            ir: new IntermediateRepresentation({
+                type: "resource",
+                ir: [new ResourceString({
+                    key: "printf.test",
+                    sourceLocale: "en-US",
+                    source: 'This string contains %0$-#05.2zd in it.',
+                    targetLocale: "de-DE",
+                    target: 'Diese Zeichenfolge enthält %0$-#05.2zd.',
+                    pathName: "a/b/c.xliff"
+                })],
+                filePath: "x"
+            })
         });
         test.ok(!actual);
 
@@ -251,15 +269,18 @@ export const testPrintfMatchRules = {
         // no parameters in source or target is okay
         const actual = rule.match({
             locale: "de-DE",
-            resource: new ResourceString({
-                key: "printf.test",
-                sourceLocale: "en-US",
-                source: 'This string contains %0$-#05.2d in it.',
-                targetLocale: "de-DE",
-                target: 'Diese Zeichenfolge enthält %0$-#05.2zd.',
-                pathName: "a/b/c.xliff"
-            }),
-            file: "x"
+            ir: new IntermediateRepresentation({
+                type: "resource",
+                ir: [new ResourceString({
+                    key: "printf.test",
+                    sourceLocale: "en-US",
+                    source: 'This string contains %0$-#05.2d in it.',
+                    targetLocale: "de-DE",
+                    target: 'Diese Zeichenfolge enthält %0$-#05.2zd.',
+                    pathName: "a/b/c.xliff"
+                })],
+                filePath: "x"
+            })
         });
         const expected = [
             new Result({
@@ -295,15 +316,18 @@ export const testPrintfMatchRules = {
         // no parameters in source or target is okay
         const actual = rule.match({
             locale: "de-DE",
-            resource: new ResourceString({
-                key: "printf.test",
-                sourceLocale: "en-US",
-                source: 'This string %0$s contains %1$s in it.',
-                targetLocale: "de-DE",
-                target: 'Diese %1$s Zeichenfolge enthält %0$s.',
-                pathName: "a/b/c.xliff"
-            }),
-            file: "x"
+            ir: new IntermediateRepresentation({
+                type: "resource",
+                ir: [new ResourceString({
+                    key: "printf.test",
+                    sourceLocale: "en-US",
+                    source: 'This string %0$s contains %1$s in it.',
+                    targetLocale: "de-DE",
+                    target: 'Diese %1$s Zeichenfolge enthält %0$s.',
+                    pathName: "a/b/c.xliff"
+                })],
+                filePath: "x"
+            })
         });
         test.ok(!actual);
 

--- a/test/testPrintfNumberedRule.js
+++ b/test/testPrintfNumberedRule.js
@@ -1,7 +1,7 @@
 /*
  * testPrintfNumberedRule.js - test the substitution parameter numbering rule
  *
- * Copyright © 2022 JEDLSoft
+ * Copyright © 2022-2023 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@ import { ResourceString } from 'ilib-tools-common';
 
 import PrintfNumberedRule from '../src/PrintfNumberedRule.js';
 
-import { Result } from 'i18nlint-common';
+import { Result, IntermediateRepresentation } from 'i18nlint-common';
 
 export const testPrintfNumberedRules = {
     testPrintfNumberedRuleStyle: function(test) {
@@ -88,13 +88,16 @@ export const testPrintfNumberedRules = {
 
         const actual = rule.match({
             locale: "de-DE",
-            resource: new ResourceString({
-                key: "printf.test",
-                sourceLocale: "en-US",
-                source: 'This %d string contains a %s string in it.',
-                pathName: "a/b/c.xliff"
-            }),
-            file: "x"
+            ir: new IntermediateRepresentation({
+                type: "resource",
+                ir: [new ResourceString({
+                    key: "printf.test",
+                    sourceLocale: "en-US",
+                    source: 'This %d string contains a %s string in it.',
+                    pathName: "a/b/c.xliff"
+                })],
+                filePath: "x"
+            })
         });
         // if the source contains native quotes, the target must too
         const expected = [
@@ -129,13 +132,16 @@ export const testPrintfNumberedRules = {
         // no parameters in source or target is okay
         const actual = rule.match({
             locale: "de-DE",
-            resource: new ResourceString({
-                key: "printf.test",
-                sourceLocale: "en-US",
-                source: 'This string contains no substitution parameters in it.',
-                pathName: "a/b/c.xliff"
-            }),
-            file: "x"
+            ir: new IntermediateRepresentation({
+                type: "resource",
+                ir: [new ResourceString({
+                    key: "printf.test",
+                    sourceLocale: "en-US",
+                    source: 'This string contains no substitution parameters in it.',
+                    pathName: "a/b/c.xliff"
+                })],
+                filePath: "x"
+            })
         });
         test.ok(!actual);
 
@@ -151,13 +157,16 @@ export const testPrintfNumberedRules = {
         // no parameters in source or target is okay
         const actual = rule.match({
             locale: "de-DE",
-            resource: new ResourceString({
-                key: "printf.test",
-                sourceLocale: "en-US",
-                source: 'This string contains a %3$s substitution parameter in it.',
-                pathName: "a/b/c.xliff"
-            }),
-            file: "x"
+            ir: new IntermediateRepresentation({
+                type: "resource",
+                ir: [new ResourceString({
+                    key: "printf.test",
+                    sourceLocale: "en-US",
+                    source: 'This string contains a %3$s substitution parameter in it.',
+                    pathName: "a/b/c.xliff"
+                })],
+                filePath: "x"
+            })
         });
         test.ok(!actual);
 
@@ -173,13 +182,16 @@ export const testPrintfNumberedRules = {
         // no parameters in source or target is okay
         const actual = rule.match({
             locale: "de-DE",
-            resource: new ResourceString({
-                key: "printf.test",
-                sourceLocale: "en-US",
-                source: 'This string contains a %s substitution parameter in it.',
-                pathName: "a/b/c.xliff"
-            }),
-            file: "x"
+            ir: new IntermediateRepresentation({
+                type: "resource",
+                ir: [new ResourceString({
+                    key: "printf.test",
+                    sourceLocale: "en-US",
+                    source: 'This string contains a %s substitution parameter in it.',
+                    pathName: "a/b/c.xliff"
+                })],
+                filePath: "x"
+            })
         });
         test.ok(!actual);
 
@@ -194,13 +206,16 @@ export const testPrintfNumberedRules = {
 
         const actual = rule.match({
             locale: "de-DE",
-            resource: new ResourceString({
-                key: "printf.test",
-                sourceLocale: "en-US",
-                source: 'This %1$d string contains a %s string in it.',
-                pathName: "a/b/c.xliff"
-            }),
-            file: "x"
+            ir: new IntermediateRepresentation({
+                type: "resource",
+                ir: [new ResourceString({
+                    key: "printf.test",
+                    sourceLocale: "en-US",
+                    source: 'This %1$d string contains a %s string in it.',
+                    pathName: "a/b/c.xliff"
+                })],
+                filePath: "x"
+            })
         });
         // if the source contains native quotes, the target must too
         const expected = new Result({
@@ -224,13 +239,16 @@ export const testPrintfNumberedRules = {
 
         const actual = rule.match({
             locale: "de-DE",
-            resource: new ResourceString({
-                key: "printf.test",
-                sourceLocale: "en-US",
-                source: 'This %1$d string contains a %s string in %2$s.',
-                pathName: "a/b/c.xliff"
-            }),
-            file: "x"
+            ir: new IntermediateRepresentation({
+                type: "resource",
+                ir: [new ResourceString({
+                    key: "printf.test",
+                    sourceLocale: "en-US",
+                    source: 'This %1$d string contains a %s string in %2$s.',
+                    pathName: "a/b/c.xliff"
+                })],
+                filePath: "x"
+            })
         });
         // if the source contains native quotes, the target must too
         const expected = new Result({
@@ -254,13 +272,16 @@ export const testPrintfNumberedRules = {
 
         const actual = rule.match({
             locale: "de-DE",
-            resource: new ResourceString({
-                key: "printf.test",
-                sourceLocale: "en-US",
-                source: 'This %1$d string contains a %s string in %s.',
-                pathName: "a/b/c.xliff"
-            }),
-            file: "x"
+            ir: new IntermediateRepresentation({
+                type: "resource",
+                ir: [new ResourceString({
+                    key: "printf.test",
+                    sourceLocale: "en-US",
+                    source: 'This %1$d string contains a %s string in %s.',
+                    pathName: "a/b/c.xliff"
+                })],
+                filePath: "x"
+            })
         });
         // if the source contains native quotes, the target must too
         const expected = [


### PR DESCRIPTION
- now uses an IntermediateRepresentation class
- updated dependencies and unit tests

I would recommend ignoring whitespace differences while looking at the diff, as much of it was merely indented.