### PR TITLE
Update from i18nlint-common to ilib-lint-common

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ file types.
 
 ## License
 
-Copyright © 2022-2023, JEDLSoft
+Copyright © 2022-2024, JEDLSoft
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -69,6 +69,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 ## Release Notes
+
+### v2.0.0
+
+- Updated dependency from i18nlint-common to ilib-lint-common
+    - IntermediateRepresentation now takes a SourceFile as an
+      parameter to the constructor instead of a file path
+    - can now be loaded by ilib-lint >= v2
 
 ### v1.2.0
 

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
     "exports": {
         ".": {
             "import": "./src/index.js"
+        },
+        "package.json": {
+            "import": "./package.json"
         }
     },
     "description": "ilib-lint plugin to check python resources using the GNU gettext library",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-lint-python-gnu",
-    "version": "1.2.1",
+    "version": "2.0.0",
     "main": "./src/index.js",
     "type": "module",
     "exports": {
@@ -32,13 +32,13 @@
         "docdash": "^2.0.2",
         "jest": "^29.7.0",
         "jsdoc": "^4.0.2",
-        "jsdoc-to-markdown": "^8.0.0",
+        "jsdoc-to-markdown": "^8.0.1",
         "npm-run-all": "^4.1.5"
     },
     "dependencies": {
-        "i18nlint-common": "^2.2.0",
+        "ilib-lint-common": "^3.0.0",
         "ilib-locale": "^1.2.2",
         "ilib-loctool-po": "^1.6.3",
-        "ilib-tools-common": "^1.8.0"
+        "ilib-tools-common": "^1.9.1"
     }
 }

--- a/src/POParser.js
+++ b/src/POParser.js
@@ -1,7 +1,7 @@
 /*
  * POParser.js - a parser for PO files
  *
- * Copyright © 2022-2023 JEDLSoft
+ * Copyright © 2022-2024 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 
-import { Parser, IntermediateRepresentation } from 'i18nlint-common';
+import { Parser, IntermediateRepresentation, SourceFile } from 'ilib-lint-common';
 import {
     ResourceString,
     ResourceArray,
@@ -76,6 +76,7 @@ const shimAPI = {
     }
 };
 
+// this is a shim between the loctool plugin ilib-loctool-po and this ilib-lint plugin
 class ShimProject {
     constructor(options) {
         this.sourceLocale = options.sourceLocale;
@@ -101,7 +102,6 @@ class POParser extends Parser {
     constructor(options) {
         super(options);
         this.name = "parser-po";
-        this.filePath = options && options.filePath;
         let projOptions = {
             sourceLocale: (options && options.sourceLocale) || "en-US",
             root: ".",
@@ -137,15 +137,16 @@ class POParser extends Parser {
 
     /**
      * Parse the current file into an intermediate representation.
+     * @param {SourceFile} sourceFile the file to parse
      */
-    parse() {
-        const pofile = this.potype.newFile(this.filePath);
+    parse(sourceFile) {
+        const pofile = this.potype.newFile(sourceFile.getPath());
         pofile.extract();
         this.ts = pofile.getTranslationSet();
         return [new IntermediateRepresentation({
             type: "resource",
             ir: this.ts.getAll(),
-            filePath: this.filePath
+            sourceFile
         })];
     }
 }

--- a/src/PrintfMatchRule.js
+++ b/src/PrintfMatchRule.js
@@ -1,7 +1,7 @@
 /*
  * PrintfMatchRule.js - a rule to match printf-style substition parameters
  *
- * Copyright © 2022-2023 JEDLSoft
+ * Copyright © 2022-2024 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@
  */
 
 import Locale from 'ilib-locale';
-import { Rule, Result } from 'i18nlint-common';
+import { Rule, Result } from 'ilib-lint-common';
 
 // from https://pubs.opengroup.org/onlinepubs/007904975/functions/fprintf.html
 const printfRegExp = /%(\d\$)?[\-\+ #0']*[\d\*]?(\.(\d*|\*))?(hh?|ll?|j|z|t|L)?[diouxXfFeEgGaAcCsSpn]/g;
@@ -137,7 +137,7 @@ class PrintfMatchRule extends Rule {
                 case 'string':
                     const tarString = resource.getTarget();
                     if (tarString) {
-                        return this.checkString(resource.getSource(), tarString, ir.getPath(), resource, sourceLocale, options.locale, options.lineNumber);
+                        return this.checkString(resource.getSource(), tarString, ir.sourceFile.getPath(), resource, sourceLocale, options.locale, options.lineNumber);
                     }
                     break;
     
@@ -147,7 +147,7 @@ class PrintfMatchRule extends Rule {
                     if (tarArray) {
                         return srcArray.flatMap((item, i) => {
                             if (i < tarArray.length && tarArray[i]) {
-                                return this.checkString(srcArray[i], tarArray[i], ir.getPath(), resource, sourceLocale, options.locale, options.lineNumber);
+                                return this.checkString(srcArray[i], tarArray[i], ir.sourceFile.getPath(), resource, sourceLocale, options.locale, options.lineNumber);
                             }
                         }).filter(element => {
                             return element;
@@ -160,7 +160,7 @@ class PrintfMatchRule extends Rule {
                     const tarPlural = resource.getTarget();
                     if (tarPlural) {
                         return categories.flatMap(category => {
-                            return this.checkString(srcPlural.other, tarPlural[category], ir.getPath(), resource, sourceLocale, options.locale, options.lineNumber);
+                            return this.checkString(srcPlural.other, tarPlural[category], ir.sourceFile.getPath(), resource, sourceLocale, options.locale, options.lineNumber);
                         });
                     }
                     break;

--- a/src/PrintfNumberedRule.js
+++ b/src/PrintfNumberedRule.js
@@ -1,7 +1,7 @@
 /*
  * PrintfMatchRule.js - a rule to match printf-style substition parameters
  *
- * Copyright © 2022-2023 JEDLSoft
+ * Copyright © 2022-2024 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@
  */
 
 import Locale from 'ilib-locale';
-import { Rule, Result } from 'i18nlint-common';
+import { Rule, Result } from 'ilib-lint-common';
 
 // from https://pubs.opengroup.org/onlinepubs/007904975/functions/fprintf.html
 const printfRegExp = /%(\d\$)?[\-\+ #0']*[\d\*]?(\.(\d*|\*))?(hh?|ll?|j|z|t|L)?[diouxXfFeEgGaAcCsSpn]/g;
@@ -92,13 +92,13 @@ class PrintfMatchRule extends Rule {
         const results = resources.flatMap(resource => {
             switch (resource.getType()) {
                 case 'string':
-                    return this.checkString(resource.getSource(), ir.getPath(), resource, options.lineNumber);
+                    return this.checkString(resource.getSource(), ir.sourceFile.getPath(), resource, options.lineNumber);
                     break;
         
                 case 'array':
                     const srcArray = resource.getSource();
                     return srcArray.flatMap((item, i) => {
-                        return this.checkString(srcArray[i], ir.getPath(), resource, options.lineNumber);
+                        return this.checkString(srcArray[i], ir.sourceFile.getPath(), resource, options.lineNumber);
                     }).filter(element => {
                         return element;
                     });
@@ -108,7 +108,7 @@ class PrintfMatchRule extends Rule {
                     const srcPlural = resource.getSource();
                     const categories = Object.keys(srcPlural);
                     return categories.flatMap(category => {
-                        return this.checkString(srcPlural[category], ir.getPath(), resource, options.lineNumber);
+                        return this.checkString(srcPlural[category], ir.sourceFile.getPath(), resource, options.lineNumber);
                     });
                     break;
             }

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 /*
  * index.js - main program of python gnu plugin
  *
- * Copyright © 2022 JEDLSoft
+ * Copyright © 2022, 2024 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 
-import { Plugin } from 'i18nlint-common';
+import { Plugin } from 'ilib-lint-common';
 
 import POParser from './POParser.js';
 import PrintfMatchRule from './PrintfMatchRule.js';

--- a/test/POParser.test.js
+++ b/test/POParser.test.js
@@ -1,7 +1,7 @@
 /*
  * POParser.test.js - test the parser factory
  *
- * Copyright © 2022-2023 JEDLSoft
+ * Copyright © 2022-2024 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 
-import { Parser } from 'i18nlint-common';
+import { Parser, SourceFile } from 'ilib-lint-common';
 
 import POParser from '../src/POParser.js';
 
@@ -33,7 +33,7 @@ describe("testPOParser", () => {
         expect.assertions(1);
 
         const parser = new POParser({
-            filePath: "./test/testfiles/test.po"
+            sourceLocale: "en-US"
         });
         expect(parser).toBeTruthy();
     });
@@ -42,10 +42,11 @@ describe("testPOParser", () => {
         expect.assertions(6);
 
         const parser = new POParser({
-            filePath: "./test/testfiles/test.po"
+            sourceLocale: "en-US"
         });
         expect(parser).toBeTruthy();
-        const irArray = parser.parse();
+        const sourceFile = new SourceFile("./test/testfiles/test.po", {});
+        const irArray = parser.parse(sourceFile);
         expect(Array.isArray(irArray)).toBeTruthy();
         expect(irArray[0].getType()).toBe("resource");
 
@@ -59,10 +60,11 @@ describe("testPOParser", () => {
         expect.assertions(19);
 
         const parser = new POParser({
-            filePath: "./test/testfiles/test.po"
+            sourceLocale: "en-US"
         });
         expect(parser).toBeTruthy();
-        const irArray = parser.parse();
+        const sourceFile = new SourceFile("./test/testfiles/test.po", {});
+        const irArray = parser.parse(sourceFile);
         expect(Array.isArray(irArray)).toBeTruthy();
 
         const resources = irArray[0].getRepresentation();
@@ -96,10 +98,11 @@ describe("testPOParser", () => {
         expect.assertions(27);
 
         const parser = new POParser({
-            filePath: "./test/testfiles/de-DE.po"
+            sourceLocale: "en-US"
         });
         expect(parser).toBeTruthy();
-        const irArray = parser.parse();
+        const sourceFile = new SourceFile("./test/testfiles/de-DE.po", {});
+        const irArray = parser.parse(sourceFile);
         expect(Array.isArray(irArray)).toBeTruthy();
 
         const resources = irArray[0].getRepresentation();
@@ -150,7 +153,8 @@ describe("testPOParser", () => {
             }
         });
         expect(parser).toBeTruthy();
-        const irArray = parser.parse();
+        const sourceFile = new SourceFile("./test/testfiles/test_de_DE.po", {});
+        const irArray = parser.parse(sourceFile);
         expect(Array.isArray(irArray)).toBeTruthy();
 
         const resources = irArray[0].getRepresentation();

--- a/test/PrintfMatchRule.test.js
+++ b/test/PrintfMatchRule.test.js
@@ -1,7 +1,7 @@
 /*
  * PrintfMatchRule.test.js - test the substitution parameter rule
  *
- * Copyright © 2022-2023 JEDLSoft
+ * Copyright © 2022-2024 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@ import { ResourceString } from 'ilib-tools-common';
 
 import PrintfMatchRule from '../src/PrintfMatchRule.js';
 
-import { Result, IntermediateRepresentation } from 'i18nlint-common';
+import { Result, IntermediateRepresentation, SourceFile } from 'ilib-lint-common';
 
 describe("testPrintfMatchRules", () => {
     test("PrintfMatchRuleStyle", () => {
@@ -76,6 +76,7 @@ describe("testPrintfMatchRules", () => {
         const rule = new PrintfMatchRule();
         expect(rule).toBeTruthy();
 
+        const sourceFile = new SourceFile("a/b/c.xliff", {});
         const actual = rule.match({
             locale: "de-DE",
             ir: new IntermediateRepresentation({
@@ -88,7 +89,7 @@ describe("testPrintfMatchRules", () => {
                     target: "Diese Zeichenfolge enthält keinen anderen Zeichenfolgen.",
                     pathName: "a/b/c.xliff"
                 })],
-                filePath: "x"
+                sourceFile
             })
         });
         // if the source contains native quotes, the target must too
@@ -99,7 +100,7 @@ describe("testPrintfMatchRules", () => {
             source: 'This string contains a %s string in it.',
             highlight: '<e0>Diese Zeichenfolge enthält keinen anderen Zeichenfolgen.</e0>',
             rule,
-            pathName: "x"
+            pathName: "a/b/c.xliff"
         });
         expect(actual).toStrictEqual(expected);
     });
@@ -110,6 +111,7 @@ describe("testPrintfMatchRules", () => {
         const rule = new PrintfMatchRule();
         expect(rule).toBeTruthy();
 
+        const sourceFile = new SourceFile("a/b/c.xliff", {});
         // no parameters in source or target is okay
         const actual = rule.match({
             locale: "de-DE",
@@ -123,7 +125,7 @@ describe("testPrintfMatchRules", () => {
                     target: 'Diese Zeichenfolge enthält "Anführungszeichen".',
                     pathName: "a/b/c.xliff"
                 })],
-                filePath: "x"
+                sourceFile
             })
         });
         expect(!actual).toBeTruthy();
@@ -135,6 +137,7 @@ describe("testPrintfMatchRules", () => {
         const rule = new PrintfMatchRule();
         expect(rule).toBeTruthy();
 
+        const sourceFile = new SourceFile("a/b/c.xliff", {});
         const actual = rule.match({
             locale: "de-DE",
             ir: new IntermediateRepresentation({
@@ -147,7 +150,7 @@ describe("testPrintfMatchRules", () => {
                     target: "Diese Zeichenfolge enthält %s anderen Zeichenfolgen %s.",
                     pathName: "a/b/c.xliff"
                 })],
-                filePath: "x"
+                sourceFile
             })
         });
         // if the source contains native quotes, the target must too
@@ -158,7 +161,7 @@ describe("testPrintfMatchRules", () => {
             source: 'This string contains a %s string in it.',
             highlight: 'Diese Zeichenfolge enthält <e0>%s</e0> anderen Zeichenfolgen <e0>%s</e0>.',
             rule,
-            pathName: "x"
+            pathName: "a/b/c.xliff"
         });
         expect(actual).toStrictEqual(expected);
     });
@@ -169,6 +172,7 @@ describe("testPrintfMatchRules", () => {
         const rule = new PrintfMatchRule();
         expect(rule).toBeTruthy();
 
+        const sourceFile = new SourceFile("a/b/c.xliff", {});
         // no parameters in source or target is okay
         const actual = rule.match({
             locale: "de-DE",
@@ -182,7 +186,7 @@ describe("testPrintfMatchRules", () => {
                     target: 'Diese Zeichenfolge enthält %s.',
                     pathName: "a/b/c.xliff"
                 })],
-                filePath: "x"
+                sourceFile
             })
         });
         expect(!actual).toBeTruthy();
@@ -194,6 +198,7 @@ describe("testPrintfMatchRules", () => {
         const rule = new PrintfMatchRule();
         expect(rule).toBeTruthy();
 
+        const sourceFile = new SourceFile("a/b/c.xliff", {});
         // no parameters in source or target is okay
         const actual = rule.match({
             locale: "de-DE",
@@ -207,7 +212,7 @@ describe("testPrintfMatchRules", () => {
                     target: 'Diese Zeichenfolge enthält %s %d.',
                     pathName: "a/b/c.xliff"
                 })],
-                filePath: "x"
+                sourceFile
             })
         });
         expect(!actual).toBeTruthy();
@@ -219,6 +224,7 @@ describe("testPrintfMatchRules", () => {
         const rule = new PrintfMatchRule();
         expect(rule).toBeTruthy();
 
+        const sourceFile = new SourceFile("a/b/c.xliff", {});
         // no parameters in source or target is okay
         const actual = rule.match({
             locale: "de-DE",
@@ -232,7 +238,7 @@ describe("testPrintfMatchRules", () => {
                     target: 'Diese Zeichenfolge enthält %0$-#05.2zd.',
                     pathName: "a/b/c.xliff"
                 })],
-                filePath: "x"
+                sourceFile
             })
         });
         expect(!actual).toBeTruthy();
@@ -244,6 +250,7 @@ describe("testPrintfMatchRules", () => {
         const rule = new PrintfMatchRule();
         expect(rule).toBeTruthy();
 
+        const sourceFile = new SourceFile("a/b/c.xliff", {});
         // no parameters in source or target is okay
         const actual = rule.match({
             locale: "de-DE",
@@ -257,7 +264,7 @@ describe("testPrintfMatchRules", () => {
                     target: 'Diese Zeichenfolge enthält %0$-#05.2zd.',
                     pathName: "a/b/c.xliff"
                 })],
-                filePath: "x"
+                sourceFile
             })
         });
         const expected = [
@@ -268,7 +275,7 @@ describe("testPrintfMatchRules", () => {
                 source: 'This string contains %0$-#05.2d in it.',
                 highlight: '<e0>Diese Zeichenfolge enthält %0$-#05.2zd.</e0>',
                 rule,
-                pathName: "x"
+                pathName: "a/b/c.xliff"
             }),
             new Result({
                 severity: "error",
@@ -277,7 +284,7 @@ describe("testPrintfMatchRules", () => {
                 source: 'This string contains %0$-#05.2d in it.',
                 highlight: 'Diese Zeichenfolge enthält <e0>%0$-#05.2zd</e0>.',
                 rule,
-                pathName: "x"
+                pathName: "a/b/c.xliff"
             })
         ];
         expect(actual).toStrictEqual(expected);
@@ -289,6 +296,7 @@ describe("testPrintfMatchRules", () => {
         const rule = new PrintfMatchRule();
         expect(rule).toBeTruthy();
 
+        const sourceFile = new SourceFile("a/b/c.xliff", {});
         // no parameters in source or target is okay
         const actual = rule.match({
             locale: "de-DE",
@@ -302,7 +310,7 @@ describe("testPrintfMatchRules", () => {
                     target: 'Diese %1$s Zeichenfolge enthält %0$s.',
                     pathName: "a/b/c.xliff"
                 })],
-                filePath: "x"
+                sourceFile
             })
         });
         expect(!actual).toBeTruthy();

--- a/test/PrintfNumberedRule.test.js
+++ b/test/PrintfNumberedRule.test.js
@@ -1,7 +1,7 @@
 /*
  * PrintfNumberedRule.test.js - test the substitution parameter numbering rule
  *
- * Copyright © 2022-2023 JEDLSoft
+ * Copyright © 2022-2024 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@ import { ResourceString } from 'ilib-tools-common';
 
 import PrintfNumberedRule from '../src/PrintfNumberedRule.js';
 
-import { Result, IntermediateRepresentation } from 'i18nlint-common';
+import { Result, IntermediateRepresentation, SourceFile } from 'ilib-lint-common';
 
 describe("testPrintfNumberedRules", () => {
     test("PrintfNumberedRuleStyle", () => {
@@ -76,6 +76,7 @@ describe("testPrintfNumberedRules", () => {
         const rule = new PrintfNumberedRule();
         expect(rule).toBeTruthy();
 
+        const sourceFile = new SourceFile("a/b/c.xliff", {});
         const actual = rule.match({
             locale: "de-DE",
             ir: new IntermediateRepresentation({
@@ -86,7 +87,7 @@ describe("testPrintfNumberedRules", () => {
                     source: 'This %d string contains a %s string in it.',
                     pathName: "a/b/c.xliff"
                 })],
-                filePath: "x"
+                sourceFile
             })
         });
         // if the source contains native quotes, the target must too
@@ -97,7 +98,7 @@ describe("testPrintfNumberedRules", () => {
                 id: "printf.test",
                 highlight: 'This <e0>%d</e0> string contains a %s string in it.',
                 rule,
-                pathName: "x"
+                pathName: "a/b/c.xliff"
             }),
             new Result({
                 severity: "error",
@@ -105,7 +106,7 @@ describe("testPrintfNumberedRules", () => {
                 id: "printf.test",
                 highlight: 'This %d string contains a <e0>%s</e0> string in it.',
                 rule,
-                pathName: "x"
+                pathName: "a/b/c.xliff"
             })
         ];
         expect(actual).toStrictEqual(expected);
@@ -117,6 +118,7 @@ describe("testPrintfNumberedRules", () => {
         const rule = new PrintfNumberedRule();
         expect(rule).toBeTruthy();
 
+        const sourceFile = new SourceFile("a/b/c.xliff", {});
         // no parameters in source or target is okay
         const actual = rule.match({
             locale: "de-DE",
@@ -128,7 +130,7 @@ describe("testPrintfNumberedRules", () => {
                     source: 'This string contains no substitution parameters in it.',
                     pathName: "a/b/c.xliff"
                 })],
-                filePath: "x"
+                sourceFile
             })
         });
         expect(!actual).toBeTruthy();
@@ -140,6 +142,7 @@ describe("testPrintfNumberedRules", () => {
         const rule = new PrintfNumberedRule();
         expect(rule).toBeTruthy();
 
+        const sourceFile = new SourceFile("a/b/c.xliff", {});
         // no parameters in source or target is okay
         const actual = rule.match({
             locale: "de-DE",
@@ -151,7 +154,7 @@ describe("testPrintfNumberedRules", () => {
                     source: 'This string contains a %3$s substitution parameter in it.',
                     pathName: "a/b/c.xliff"
                 })],
-                filePath: "x"
+                sourceFile
             })
         });
         expect(!actual).toBeTruthy();
@@ -163,6 +166,7 @@ describe("testPrintfNumberedRules", () => {
         const rule = new PrintfNumberedRule();
         expect(rule).toBeTruthy();
 
+        const sourceFile = new SourceFile("a/b/c.xliff", {});
         // no parameters in source or target is okay
         const actual = rule.match({
             locale: "de-DE",
@@ -174,7 +178,7 @@ describe("testPrintfNumberedRules", () => {
                     source: 'This string contains a %s substitution parameter in it.',
                     pathName: "a/b/c.xliff"
                 })],
-                filePath: "x"
+                sourceFile
             })
         });
         expect(!actual).toBeTruthy();
@@ -186,6 +190,7 @@ describe("testPrintfNumberedRules", () => {
         const rule = new PrintfNumberedRule();
         expect(rule).toBeTruthy();
 
+        const sourceFile = new SourceFile("a/b/c.xliff", {});
         const actual = rule.match({
             locale: "de-DE",
             ir: new IntermediateRepresentation({
@@ -196,7 +201,7 @@ describe("testPrintfNumberedRules", () => {
                     source: 'This %1$d string contains a %s string in it.',
                     pathName: "a/b/c.xliff"
                 })],
-                filePath: "x"
+                sourceFile
             })
         });
         // if the source contains native quotes, the target must too
@@ -206,7 +211,7 @@ describe("testPrintfNumberedRules", () => {
             id: "printf.test",
             highlight: 'This %1$d string contains a <e0>%s</e0> string in it.',
             rule,
-            pathName: "x"
+            pathName: "a/b/c.xliff"
         });
         expect(actual).toStrictEqual(expected);
     });
@@ -217,6 +222,7 @@ describe("testPrintfNumberedRules", () => {
         const rule = new PrintfNumberedRule();
         expect(rule).toBeTruthy();
 
+        const sourceFile = new SourceFile("a/b/c.xliff", {});
         const actual = rule.match({
             locale: "de-DE",
             ir: new IntermediateRepresentation({
@@ -227,7 +233,7 @@ describe("testPrintfNumberedRules", () => {
                     source: 'This %1$d string contains a %s string in %2$s.',
                     pathName: "a/b/c.xliff"
                 })],
-                filePath: "x"
+                sourceFile
             })
         });
         // if the source contains native quotes, the target must too
@@ -237,7 +243,7 @@ describe("testPrintfNumberedRules", () => {
             id: "printf.test",
             highlight: 'This %1$d string contains a <e0>%s</e0> string in %2$s.',
             rule,
-            pathName: "x"
+            pathName: "a/b/c.xliff"
         });
         expect(actual).toStrictEqual(expected);
     });
@@ -248,6 +254,7 @@ describe("testPrintfNumberedRules", () => {
         const rule = new PrintfNumberedRule();
         expect(rule).toBeTruthy();
 
+        const sourceFile = new SourceFile("a/b/c.xliff", {});
         const actual = rule.match({
             locale: "de-DE",
             ir: new IntermediateRepresentation({
@@ -258,7 +265,7 @@ describe("testPrintfNumberedRules", () => {
                     source: 'This %1$d string contains a %s string in %s.',
                     pathName: "a/b/c.xliff"
                 })],
-                filePath: "x"
+                sourceFile
             })
         });
         // if the source contains native quotes, the target must too
@@ -269,7 +276,7 @@ describe("testPrintfNumberedRules", () => {
                 id: "printf.test",
                 highlight: 'This %1$d string contains a <e0>%s</e0> string in <e0>%s</e0>.',
                 rule,
-                pathName: "x"
+                pathName: "a/b/c.xliff"
             }),
             new Result({
                 severity: "error",
@@ -277,7 +284,7 @@ describe("testPrintfNumberedRules", () => {
                 id: "printf.test",
                 highlight: 'This %1$d string contains a <e0>%s</e0> string in <e0>%s</e0>.',
                 rule,
-                pathName: "x"
+                pathName: "a/b/c.xliff"
             })
         ];
         expect(actual).toStrictEqual(expected);

--- a/test/PythonGnuPlugin.test.js
+++ b/test/PythonGnuPlugin.test.js
@@ -1,7 +1,7 @@
 /*
  * PythonGnuPlugin.test.js - test the Xliff plugin
  *
- * Copyright ©  2022-2023JEDLSoft
+ * Copyright © 2022-2024 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Parser } from 'i18nlint-common';
+import { Parser } from 'ilib-lint-common';
 
 import PythonPlugin from '../src/index.js';
 


### PR DESCRIPTION
- Updated dependency from i18nlint-common to ilib-lint-common
    - IntermediateRepresentation now takes a SourceFile as an
      parameter to the constructor instead of a file path
    - can now be loaded by ilib-lint >= v2
- draft PR until I can test this with ilib-lint directly